### PR TITLE
Preserve assistant context when patching other fields

### DIFF
--- a/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/ops.py
+++ b/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/ops.py
@@ -572,7 +572,7 @@ def _materialize_page(
     return items
 
 
-def _normalize_config_context(config: dict, context: dict) -> tuple[dict, dict]:
+def _normalize_config_context(config: dict, context: dict | None) -> tuple[dict, dict | None]:
     """Reconcile config.configurable and context; raises if both provided."""
     if config.get("configurable") and context:
         raise HTTPException(
@@ -937,7 +937,7 @@ class Assistants(Authenticated):
 
         if graph_id is not None:
             _assert_graph_exists(graph_id)
-        config, context = _normalize_config_context(config, context or {})
+        config, context = _normalize_config_context(config, context)
 
         # Lock so concurrent patches cannot allocate the same version (PK on assistant_versions).
         assistant = (

--- a/libs/langgraph-runtime-pg/tests/test_assistants.py
+++ b/libs/langgraph-runtime-pg/tests/test_assistants.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.usefixtures("pg_runtime")
+async def test_patch_preserves_context_when_omitted() -> None:
+    from langgraph_runtime_pg import ops
+    from langgraph_runtime_pg.database import connect
+
+    assistant_id = uuid.uuid4()
+    original_context = {"tenant_id": "tenant-1", "role": "support"}
+
+    async with connect() as conn:
+        await anext(
+            await ops.Assistants.put(
+                conn,
+                assistant_id,
+                graph_id="g1",
+                context=original_context,
+                metadata={"revision": 1},
+            )
+        )
+
+    async with connect() as conn:
+        patched = await anext(
+            await ops.Assistants.patch(
+                conn,
+                assistant_id,
+                name="renamed",
+                metadata={"revision": 2},
+            )
+        )
+        versions = [
+            version async for version in await ops.Assistants.get_versions(conn, assistant_id)
+        ]
+
+    assert patched["context"] == original_context
+    assert versions[0]["context"] == original_context
+
+
+@pytest.mark.usefixtures("pg_runtime")
+async def test_patch_can_explicitly_clear_context() -> None:
+    from langgraph_runtime_pg import ops
+    from langgraph_runtime_pg.database import connect
+
+    assistant_id = uuid.uuid4()
+
+    async with connect() as conn:
+        await anext(
+            await ops.Assistants.put(
+                conn,
+                assistant_id,
+                graph_id="g1",
+                context={"tenant_id": "tenant-1"},
+            )
+        )
+
+    async with connect() as conn:
+        patched = await anext(await ops.Assistants.patch(conn, assistant_id, context={}))
+
+    assert patched["context"] == {}


### PR DESCRIPTION
## Summary

- Preserve an assistant's stored `context` when `Assistants.patch` omits the field.
- Continue allowing an explicitly supplied empty context (`context={}`) to clear it.
- Add regression tests covering both the assistant row and the new assistant-version snapshot.

## Root cause

`Assistants.patch` normalized `context` using `context or {}`. This converted an omitted value (`None`) into `{}` before `_apply_assistant_patch_fields` could distinguish between “not supplied” and “explicitly empty.”

As a result, metadata-only or name-only updates silently replaced the stored context with `{}` and recorded that data loss in `assistant_versions`.