### PR TITLE
Retry run heartbeats after transient Redis failures

### DIFF
--- a/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/ops.py
+++ b/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/ops.py
@@ -2396,6 +2396,34 @@ def _build_exclude_sql(blocked_threads: list) -> tuple[str, dict]:
     return exclude_sql, params
 
 
+async def _run_heartbeat_loop(run_id: UUID) -> None:
+    """Refresh a run heartbeat until cancelled, retrying transient Redis failures."""
+    interval = heartbeat_refresh_interval_secs()
+    retry_interval = min(interval, 5.0)
+    consecutive_failures = 0
+    while True:
+        try:
+            await set_run_heartbeat(run_id)
+        except Exception:
+            consecutive_failures += 1
+            logger.exception(
+                "Run heartbeat refresh failed; retrying",
+                run_id=str(run_id),
+                consecutive_failures=consecutive_failures,
+                retry_interval=retry_interval,
+            )
+            await asyncio.sleep(retry_interval)
+            continue
+        if consecutive_failures:
+            logger.info(
+                "Run heartbeat refresh recovered",
+                run_id=str(run_id),
+                consecutive_failures=consecutive_failures,
+            )
+            consecutive_failures = 0
+        await asyncio.sleep(interval)
+
+
 async def _ensure_run_thread(
     conn: PgConnectionProto,
     thread_id: UUID | None,
@@ -3265,17 +3293,11 @@ class Runs(Authenticated):
         stream_manager = get_stream_manager()
         control_queue = await stream_manager.add_control_queue(run_id, thread_id)
 
-        async def _heartbeat_loop() -> None:
-            interval = heartbeat_refresh_interval_secs()
-            while True:
-                await set_run_heartbeat(run_id)
-                await asyncio.sleep(interval)
-
         try:
             await set_run_heartbeat(run_id)
             async with SimpleTaskGroup(cancel=True, taskgroup_name="Runs.enter") as tg:
                 done = ValueEvent()
-                tg.create_task(_heartbeat_loop())
+                tg.create_task(_run_heartbeat_loop(run_id))
                 tg.create_task(listen_for_cancellation(control_queue, run_id, thread_id, done))
                 yield done
                 control_message = Message(topic=f"run:{run_id}:control".encode(), data=b"done")

--- a/libs/langgraph-runtime-pg/tests/test_queue.py
+++ b/libs/langgraph-runtime-pg/tests/test_queue.py
@@ -33,6 +33,33 @@ async def _seed_pending_run():
         )
 
 
+async def test_heartbeat_loop_recovers_after_transient_redis_error(monkeypatch):
+    from langgraph_runtime_pg import ops
+
+    attempts = 0
+    recovered = asyncio.Event()
+
+    async def _set_heartbeat(_run_id):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("transient Redis failure")
+        recovered.set()
+
+    monkeypatch.setattr(ops, "set_run_heartbeat", _set_heartbeat)
+    monkeypatch.setattr(ops, "heartbeat_refresh_interval_secs", lambda: 0.01)
+
+    task = asyncio.create_task(ops._run_heartbeat_loop(uuid.uuid4()))
+    try:
+        await asyncio.wait_for(recovered.wait(), timeout=1)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert attempts == 2
+
+
 async def test_exactly_one_claim(pg_runtime):
     from langgraph_runtime_pg import ops
     from langgraph_runtime_pg.database import connect


### PR DESCRIPTION
## Summary

- Keep the run heartbeat task alive after transient Redis failures.
- Retry failed heartbeat refreshes with a short backoff of at most five seconds.
- Log consecutive failures and successful recovery.
- Add regression coverage proving the heartbeat loop recovers after a failed refresh.

## Root cause

The heartbeat loop did not handle exceptions from Redis. A single timeout, failover, or connection error permanently terminated the background heartbeat task while the run continued executing.

After the heartbeat key expired, the sweeper could mark the live run as pending, allowing another worker to claim and execute it concurrently.

## Validation

- Ruff formatting and lint checks pass.
- Mypy passes.
- First-party test suite: `30 passed, 14 skipped`.