### PR TITLE
Add independent project disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 </p>
 
 <p align="center">
+  <strong>Independent project; not affiliated with or endorsed by LangChain.</strong>
+</p>
+
+<p align="center">
   <a href="https://github.com/langhost/langhost/stargazers"><img src="https://img.shields.io/github/stars/langhost/langhost?style=social" alt="GitHub stars"></a>
   &nbsp;
   <a href="https://github.com/langhost/langhost/actions/workflows/ci.yml"><img src="https://github.com/langhost/langhost/actions/workflows/ci.yml/badge.svg" alt="CI"></a>


### PR DESCRIPTION
## What changed

- Added a prominent independence disclaimer near the top of the README.
- States that Langhost is not affiliated with or endorsed by LangChain.

## Why

The disclaimer makes the project’s relationship to LangChain immediately clear and reduces the risk of readers interpreting compatibility claims as official affiliation or endorsement.

## Impact

Documentation only. No package, runtime, or API behavior changes.
