### PR TITLE
Add Aegra to the LangHost comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ Compatible with:
 
 ## Why langhost?
 
-| | `langgraph dev` | LangSmith Deployments | **langhost** |
-|:--|:--|:--|:--|
-| **Best for** | Quick local experiments | Managed / licensed prod | Self-hosted prod on your infra |
-| **Storage** | In-memory / local | Closed Postgres + Redis | **Open MIT Postgres + Redis** |
-| **HTTP stack** | Official Agent Server | Official Agent Server | **Official `langgraph-api`** |
-| **Studio / SDK** | Yes | Yes | **Yes — same clients** |
-| **License key for runtime** | N/A | Often required | **None (MIT)** |
+| | `langgraph dev` | LangSmith Deployments | [Aegra](https://github.com/aegra/aegra) | **langhost** |
+|:--|:--|:--|:--|:--|
+| **Best for** | Quick local experiments | Managed / licensed prod | Open, customizable server stack | Official server on your infra |
+| **Storage** | In-memory / local | Closed Postgres + Redis | Open Apache-2.0 Postgres + Redis | **Open MIT Postgres + Redis** |
+| **HTTP stack** | Official Agent Server | Official Agent Server | Independent FastAPI implementation | **Official `langgraph-api`** |
+| **Studio / SDK** | Yes | Yes | Yes — compatible clients | **Yes — same clients** |
+| **License key for runtime** | N/A | Often required | None (Apache-2.0) | **None (MIT)** |
 
-Official [`langgraph dev`](https://docs.langchain.com/oss/python/langgraph/local-server) is perfect for in-memory development. **langhost** is the open-source path when you want that same Agent Server experience with durable state.
+Official [`langgraph dev`](https://docs.langchain.com/oss/python/langgraph/local-server) is perfect for in-memory development. [Aegra](https://github.com/aegra/aegra) reimplements the Agent Protocol serving layer as an open FastAPI stack. **langhost** takes a narrower, compatibility-first approach: it keeps the stock `langgraph-api` server and replaces its closed persistence runtime, giving you the official Agent Server experience with durable state.
 
 ## How it fits together
 


### PR DESCRIPTION
## Summary

- Add Aegra to the **Why langhost?** comparison table.
- Compare its use case, storage, HTTP stack, client compatibility, and runtime licensing.
- Explain the architectural difference: Aegra reimplements the Agent Protocol server with FastAPI, while LangHost keeps the stock `langgraph-api` server and replaces the persistence runtime.

## Test plan

- [x] `git diff --check`
- [x] Cross-checked the claims against Aegra's official repository and feature documentation.
- [x] Documentation-only change; migrations are not applicable.

## Notes

This gives readers a clearer way to choose between a customizable open server implementation and LangHost's compatibility-first approach.