### PR TITLE
Fix live Protocol v3 stream completion hangs

### DIFF
--- a/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/redis_stream.py
+++ b/libs/langgraph-runtime-pg/src/langgraph_runtime_pg/redis_stream.py
@@ -405,7 +405,16 @@ class StreamManager:
         already_locked: bool = False,
     ) -> None:
         async def _do() -> None:
-            if not self._mark_seen(f"run:{thread_id}:{run_id}", message):
+            # Control messages and resumable stream messages use independent
+            # ID generators. At run completion the raw ``control/done`` and
+            # encoded stream ``control/done`` are published back-to-back, so
+            # both can legitimately receive the same millisecond-sequence ID.
+            # Deduplicating across those lanes drops the stream completion and
+            # leaves live Protocol v3 projections waiting forever. Keep dedup
+            # within each delivery lane; Redis Pub/Sub echoes still collapse,
+            # while the distinct control and stream messages both fan out.
+            lane = "control" if control else "stream"
+            if not self._mark_seen(f"run:{thread_id}:{run_id}:{lane}", message):
                 return
             if control:
                 self.control_keys[thread_id][run_id] = message

--- a/libs/langgraph-runtime-pg/tests/test_e2e.py
+++ b/libs/langgraph-runtime-pg/tests/test_e2e.py
@@ -86,6 +86,19 @@ async def test_deep_agent_wait_completes(async_sdk) -> None:
         await async_sdk.threads.delete(tid)
 
 
+async def test_deep_agent_subgraphs_stream_reaches_terminal(async_threads) -> None:
+    """A live projection must receive run completion, not only replay observers."""
+    threads, _ = async_threads
+    async with threads.stream(assistant_id=DEEP_AGENT_ASSISTANT_ID) as thread:
+        await thread.run.start(input=DEEP_INPUT)
+
+        async def collect_subgraphs():
+            return [handle async for handle in thread.subgraphs]
+
+        handles = await asyncio.wait_for(collect_subgraphs(), timeout=15)
+        assert handles, "deep_agent should produce at least one direct-child handle"
+
+
 async def test_tools_agent_tool_calls_channel(async_threads) -> None:
     threads, _ = async_threads
     async with threads.stream(assistant_id=TOOLS_ASSISTANT_ID) as thread:

--- a/libs/langgraph-runtime-pg/tests/test_queue.py
+++ b/libs/langgraph-runtime-pg/tests/test_queue.py
@@ -540,6 +540,39 @@ async def test_pubsub_fanout_across_managers(pg_runtime):
     await client_b.aclose()
 
 
+async def test_control_and_stream_messages_with_same_id_both_fan_out(pg_runtime):
+    """Control and stream lanes may independently generate the same entry ID."""
+    from langgraph_api.utils.stream_codec import STREAM_CODEC
+
+    from langgraph_runtime_pg.redis_stream import Message, get_stream_manager
+
+    sm = get_stream_manager()
+    run_id, thread_id = uuid.uuid4(), uuid.uuid4()
+    run_queue = await sm.add_queue(run_id, thread_id, replay=False)
+    control_queue = await sm.add_control_queue(run_id, thread_id)
+    shared_id = b"1234567890000-0"
+    raw_control = Message(
+        topic=f"run:{run_id}:control".encode(),
+        data=b"done",
+        id=shared_id,
+    )
+    stream_control = Message(
+        topic=f"run:{run_id}:stream".encode(),
+        data=STREAM_CODEC.encode("control", b"done"),
+        id=shared_id,
+    )
+
+    try:
+        await sm._deliver_local(thread_id, run_id, raw_control, control=True)
+        await sm._deliver_local(thread_id, run_id, stream_control, control=False)
+
+        assert await asyncio.wait_for(control_queue.get(), timeout=1) is raw_control
+        assert await asyncio.wait_for(run_queue.get(), timeout=1) is stream_control
+    finally:
+        await sm.remove_control_queue(run_id, thread_id, control_queue)
+        await sm.remove_queue(run_id, thread_id, run_queue)
+
+
 async def test_thread_stream_dash_replays_redis_when_local_buffer_empty(pg_runtime):
     """Join with last_event_id='-' must replay from Redis when local buffer is empty."""
     from langgraph_api.utils.stream_codec import STREAM_CODEC


### PR DESCRIPTION
## Summary

- Separate Redis fanout deduplication for control and event-stream messages.
- Prevent a same-ID collision from dropping the terminal Protocol v3 stream event.
- Add focused queue coverage and a live deep-agent subgraph regression test.

## Root cause

Run completion publishes a raw control message and an encoded resumable stream message back-to-back. These lanes use independent ID generators and can produce the same millisecond-sequence ID. The shared deduplication scope treated the stream message as a duplicate, so active projections never received the root lifecycle completion event and waited until the CI timeout. Late observers passed because Redis still held the resumable event for replay.

## Validation

- Previously flaky async and sync subgraph/tools tests: 40/40 repeated runs passed
- Upstream SDK integration suite: 55 passed
- First-party live-server E2E suite: 14 passed
- Non-E2E suite: 35 passed
- Ruff format, Ruff lint, and mypy passed
